### PR TITLE
refactor(backend): replace OpenAI SDK + OpenRouter client with LiteLLM

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,14 @@
-GEMINI_API_KEY=your-gemini-api-key-here
-GEMINI_MODEL=gemini-2.0-flash
-GEMINI_EMBEDDING_MODEL=text-embedding-004
+# ── LLM Provider API Keys ──────────────────────────────────────────────────
+GEMINI_API_KEY=your-gemini-api-key-here          # Required: Gemini embeddings
+OPENROUTER_API_KEY=your-openrouter-api-key-here  # Required: all LLM completions via OpenRouter
+
+# ── Embedding Model ────────────────────────────────────────────────────────
+# Changing this invalidates the existing embedding cache (backend/cache/).
+GEMINI_EMBEDDING_MODEL=gemini-embedding-001
+
+# ── Default LLM (must match a key in AVAILABLE_MODELS in config.py) ────────
+DEFAULT_MODEL_KEY=gemini-2.5-flash
+
+# ── GraphDB ────────────────────────────────────────────────────────────────
 GRAPHDB_URL=http://localhost:7200
 GRAPHDB_REPO=GEMR

--- a/backend/config.py
+++ b/backend/config.py
@@ -13,46 +13,47 @@ load_dotenv(BACKEND_DIR / ".env")
 # Project root (one level up from backend/)
 PROJECT_ROOT = BACKEND_DIR.parent
 
-# --- Gemini API (still used for embeddings, cached on disk) ---
+# --- Gemini API (used for embeddings via google-genai; cached on disk) ---
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
-GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.0-flash")  # legacy; not used by runtime any more
 GEMINI_EMBEDDING_MODEL = os.getenv("GEMINI_EMBEDDING_MODEL", "gemini-embedding-001")
 
-# --- OpenRouter API (primary LLM provider, matches the evaluation pipeline) ---
+# --- OpenRouter (primary LLM provider) ---
+# LiteLLM reads OPENROUTER_API_KEY automatically for any model with the
+# "openrouter/" prefix — no extra client setup required.
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
-# Model registry — short keys the frontend picks from, mapped to OpenRouter IDs.
+# Model registry — short keys the frontend picks from, mapped to LiteLLM model IDs.
+# LiteLLM routes "openrouter/<id>" through OpenRouter using OPENROUTER_API_KEY.
 # 'gemini-2.5-flash' is the default because it scored 78.1% AA (vs best baseline
 # 5.5%) on the 73-question benchmark while being the fastest system (2.5s avg).
 AVAILABLE_MODELS: dict[str, dict] = {
     "gemini-2.5-flash": {
-        "id": "google/gemini-2.5-flash",
+        "id": "openrouter/google/gemini-2.5-flash",
         "display_name": "Gemini 2.5 Flash (default, best AA)",
         "notes": "Fastest and highest answer-accuracy in benchmark.",
     },
     "claude-haiku": {
-        "id": "anthropic/claude-haiku-4.5",
+        "id": "openrouter/anthropic/claude-haiku-4.5",
         "display_name": "Claude Haiku 4.5",
         "notes": "Fast and cheap; strong syntactic compliance.",
     },
     "claude-sonnet": {
-        "id": "anthropic/claude-sonnet-4.6",
+        "id": "openrouter/anthropic/claude-sonnet-4.6",
         "display_name": "Claude Sonnet 4.6",
         "notes": "Most accurate Claude; slower.",
     },
     "claude-opus": {
-        "id": "anthropic/claude-opus-4.6",
+        "id": "openrouter/anthropic/claude-opus-4.6",
         "display_name": "Claude Opus 4.6",
         "notes": "Largest Claude.",
     },
     "gpt-5-mini": {
-        "id": "openai/gpt-5-mini",
+        "id": "openrouter/openai/gpt-5-mini",
         "display_name": "GPT-5 Mini (reasoning)",
         "notes": "OpenAI reasoning model; cheaper than GPT-5.",
     },
     "gpt-5": {
-        "id": "openai/gpt-5",
+        "id": "openrouter/openai/gpt-5",
         "display_name": "GPT-5 (reasoning)",
         "notes": "Slowest in benchmark (~45 s/q); reasoning-first.",
     },

--- a/backend/main.py
+++ b/backend/main.py
@@ -135,7 +135,7 @@ async def list_models():
         "default": DEFAULT_MODEL_KEY,
         "models": [
             {"key": key, "display_name": info["display_name"],
-             "openrouter_id": info["id"], "notes": info["notes"]}
+             "model_id": info["id"], "notes": info["notes"]}
             for key, info in AVAILABLE_MODELS.items()
         ],
     }

--- a/backend/pipeline/answer_generator.py
+++ b/backend/pipeline/answer_generator.py
@@ -1,12 +1,16 @@
 """
 Answer Generator — produces a natural-language summary of GraphDB results.
 
-Uses the same OpenRouter client / model registry as the SPARQL generator so
-a single `model_key` controls the whole pipeline.
+Uses LiteLLM for the same provider-agnostic access as the SPARQL generator.
 """
+import logging
 import time
 
-from .sparql_generator import _get_client, resolve_model
+import litellm
+
+from .sparql_generator import resolve_model
+
+logger = logging.getLogger(__name__)
 
 
 def generate_natural_language_answer(
@@ -56,27 +60,28 @@ INSTRUCTIONS:
 5. DO NOT explain the graph database, the SPARQL query, or the pipeline."""
 
     model_id, _ = resolve_model(model_key)
-    client = _get_client()
-    is_gpt5 = "gpt-5" in model_id
+    is_reasoning = any(x in model_id for x in ("o1", "o3", "gpt-5"))
 
     for attempt in range(3):
         try:
             kwargs: dict = {
                 "model": model_id,
                 "messages": [{"role": "user", "content": prompt}],
+                "drop_params": True,
             }
-            if is_gpt5:
+            if is_reasoning:
                 kwargs["max_completion_tokens"] = 2000
             else:
                 kwargs["temperature"] = 0.3
                 kwargs["max_tokens"] = 800
-            response = client.chat.completions.create(**kwargs)
+
+            response = litellm.completion(**kwargs)
             return response.choices[0].message.content or ""
         except Exception as e:
             err = str(e)
             if any(x in err for x in ("429", "rate_limit", "RESOURCE_EXHAUSTED", "529", "503")):
                 wait = 10 * (attempt + 1)
-                print(f"  [Answer Gen] rate-limited on {model_id}, waiting {wait}s...")
+                logger.warning("Rate-limited on %s, retrying in %ds (attempt %d/3)", model_id, wait, attempt + 1)
                 time.sleep(wait)
                 continue
             raise

--- a/backend/pipeline/sparql_generator.py
+++ b/backend/pipeline/sparql_generator.py
@@ -1,40 +1,26 @@
 """
-SPARQL Generator — calls OpenRouter to generate SPARQL from a structured prompt.
+SPARQL Generator — calls the configured LLM to generate SPARQL from a structured prompt.
 
-Matches the evaluation pipeline in `evaluation/pipeline_evaluator.py`:
-  - OpenRouter via OpenAI SDK (base_url = https://openrouter.ai/api/v1)
-  - default model = AVAILABLE_MODELS[DEFAULT_MODEL_KEY] (Gemini 2.5 Flash)
-  - caller may override per request via `model_key` arg
+Uses LiteLLM for provider-agnostic access (Gemini, Anthropic, OpenAI, etc.).
 """
+import logging
 import re
 import time
 
-from openai import OpenAI
+import litellm
 
-from ..config import (
-    AVAILABLE_MODELS,
-    DEFAULT_MODEL_KEY,
-    OPENROUTER_API_KEY,
-    OPENROUTER_BASE_URL,
-)
+from ..config import AVAILABLE_MODELS, DEFAULT_MODEL_KEY
 
+logger = logging.getLogger(__name__)
 
-_client: OpenAI | None = None
-
-
-def _get_client() -> OpenAI:
-    global _client
-    if _client is None:
-        if not OPENROUTER_API_KEY:
-            raise RuntimeError("OPENROUTER_API_KEY is not set in backend/.env")
-        _client = OpenAI(api_key=OPENROUTER_API_KEY, base_url=OPENROUTER_BASE_URL)
-    return _client
+# Suppress LiteLLM's verbose default output
+litellm.suppress_debug_info = True
 
 
 def resolve_model(model_key: str | None) -> tuple[str, str]:
-    """Map a short UI key (or None) to the OpenRouter model id.
+    """Map a short UI key (or None) to the LiteLLM model id.
 
-    Returns (openrouter_model_id, resolved_short_key).
+    Returns (litellm_model_id, resolved_short_key).
     Falls back to the default if the key is unknown.
     """
     key = model_key or DEFAULT_MODEL_KEY
@@ -68,18 +54,16 @@ def generate_sparql(
     query_prompt: str,
     model_key: str | None = None,
 ) -> str:
-    """Call the chosen LLM (via OpenRouter) to produce SPARQL.
+    """Call the chosen LLM via LiteLLM to produce SPARQL.
 
     Args:
         system_prompt: The static ontology-aware system prompt.
-        query_prompt: The per-question prompt (includes grounded IRIs).
-        model_key:    Optional short key from AVAILABLE_MODELS; None → default.
+        query_prompt:  The per-question prompt (includes grounded IRIs).
+        model_key:     Optional short key from AVAILABLE_MODELS; None → default.
     """
     model_id, _ = resolve_model(model_key)
-    client = _get_client()
-
-    # GPT-5 reasoning models reject `max_tokens` and `temperature != 1`.
-    is_gpt5 = "gpt-5" in model_id
+    # Reasoning models (o1/o3/gpt-5 family) reject temperature and use max_completion_tokens
+    is_reasoning = any(x in model_id for x in ("o1", "o3", "gpt-5"))
 
     for attempt in range(3):
         try:
@@ -89,20 +73,22 @@ def generate_sparql(
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": query_prompt},
                 ],
+                "drop_params": True,  # silently drop params unsupported by the provider
             }
-            if is_gpt5:
+            if is_reasoning:
                 kwargs["max_completion_tokens"] = 6000
             else:
                 kwargs["temperature"] = 0.1
                 kwargs["max_tokens"] = 2048
-            response = client.chat.completions.create(**kwargs)
+
+            response = litellm.completion(**kwargs)
             raw = response.choices[0].message.content or ""
             return _extract_sparql(raw)
         except Exception as e:
             err = str(e)
             if any(x in err for x in ("429", "rate_limit", "RESOURCE_EXHAUSTED", "529", "503")):
                 wait = 10 * (attempt + 1)
-                print(f"  [Generator] rate-limited on {model_id}, waiting {wait}s...")
+                logger.warning("Rate-limited on %s, retrying in %ds (attempt %d/3)", model_id, wait, attempt + 1)
                 time.sleep(wait)
                 continue
             raise

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 # Core dependencies for GEMR-KG NL→SPARQL Pipeline
-google-genai==1.73.1       # Gemini 2.0 API (LLM + Embeddings)
+litellm>=1.40.0            # Unified LLM provider interface (OpenAI, Anthropic, Gemini, etc.)
+google-genai==1.73.1       # Gemini embeddings (ontology grounding cache)
 fastapi==0.135.3           # API server
 uvicorn==0.44.0            # ASGI server
 requests==2.33.1           # HTTP client (GraphDB queries)


### PR DESCRIPTION
Swaps the manual OpenAI-SDK-pointed-at-OpenRouter plumbing for LiteLLM, giving a single provider-agnostic interface for all LLM completions. OpenRouter remains the active provider via the openrouter/ model prefix.

- Add litellm to requirements.txt (fixes undeclared openai dependency)
- Update config.py: model IDs use openrouter/<provider>/<model> format
- Rewrite sparql_generator.py: remove _client/_get_client, use litellm.completion()
- Rewrite answer_generator.py: same swap, drop _get_client import
- Add drop_params=True for silent provider-compatibility handling
- Replace print() rate-limit logs with logger.warning()
- Fix /api/models response field openrouter_id → model_id
- Update .env.example to reflect required keys